### PR TITLE
Add some fixes and enhancements

### DIFF
--- a/install-kcp.yaml
+++ b/install-kcp.yaml
@@ -33,7 +33,7 @@
 
   - name: Ensure root directory
     ansible.builtin.file:
-      path: /etc/kcp
+      path: "{{ kcp_rootdir }}"
       state: directory
     become: true
 

--- a/install-kcp.yaml
+++ b/install-kcp.yaml
@@ -25,11 +25,10 @@
     become: true
 
   - name: Install systemd unit
-    ansible.builtin.copy:
-      content: "{{ lookup('ansible.builtin.template', 'kcp.service.j2') }}"
+    ansible.builtin.template:
+      src: kcp.service.j2
       dest: /etc/systemd/system/kcp.service
-      remote_src: yes
-      force: true
+      mode: "0644"
     become: true
 
   - name: Ensure root directory

--- a/install-kcp.yaml
+++ b/install-kcp.yaml
@@ -10,6 +10,12 @@
     kcp_baseurl: https://github.com/kcp-dev/kcp/releases/download
     host_os: "{{ ansible_facts['system'] | lower }}"
     host_arch: "{{ ansible_facts['architecture'] | regex_replace('aarch64', 'arm64') | regex_replace('x86_64', 'amd64') }}"
+  handlers:
+    - name: Restart kcp
+      ansible.builtin.systemd:
+        name: kcp
+        state: restarted
+      become: true
 #
   tasks:
 #
@@ -23,6 +29,7 @@
       - kcp
       - kubectl-kcp-plugin
     become: true
+    notify: Restart kcp
 
   - name: Install systemd unit
     ansible.builtin.template:
@@ -30,6 +37,7 @@
       dest: /etc/systemd/system/kcp.service
       mode: "0644"
     become: true
+    notify: Restart kcp
 
   - name: Ensure root directory
     ansible.builtin.file:
@@ -40,7 +48,7 @@
   - name: Enable and Start kcp systemd service on port {{ kcp_secure_port }}
     ansible.builtin.systemd:
       name: kcp
-      state: restarted
+      state: started
       enabled: true
       daemon_reload: true
     become: true

--- a/install-kcp.yaml
+++ b/install-kcp.yaml
@@ -8,8 +8,8 @@
     kcp_rootdir: /etc/kcp
     kcp_kubeconfig_mode: 0644
     kcp_baseurl: https://github.com/kcp-dev/kcp/releases/download
-    host_os: "{{ lookup('ansible.builtin.pipe', 'uname -s') | lower }}"
-    host_arch: "{{ lookup('ansible.builtin.pipe', 'uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/') }}"
+    host_os: "{{ ansible_facts['system'] | lower }}"
+    host_arch: "{{ ansible_facts['architecture'] | regex_replace('aarch64', 'arm64') | regex_replace('x86_64', 'amd64') }}"
 #
   tasks:
 #

--- a/install-kcp.yaml
+++ b/install-kcp.yaml
@@ -51,6 +51,11 @@
       mode: "{{ kcp_kubeconfig_mode }}"
     become: true
 
+  - name: Wait for the admin.kubeconfig file to be created
+    ansible.builtin.wait_for:
+      path: "{{ kcp_rootdir }}/admin.kubeconfig"
+      state: present
+
   - name: Run this command to access kcp
     debug:
       msg: 


### PR DESCRIPTION
- Use ansible facts for os and arch values
- Use template instead of copy
- Add missing kcp_rootdir variable usage
- Wait for admin.kubeconfig to be created
- Only restart kcp on binary/systemd changes